### PR TITLE
Stop entities on fuel exhaustion and flag it in metrics screen

### DIFF
--- a/grid_sim/metrics.py
+++ b/grid_sim/metrics.py
@@ -104,6 +104,7 @@ class EntityMetrics:
     total_steps: int = 0
     total_movement_cost: float = 0.0   # normalized cost accumulator
     detected_entities: List = field(default_factory=list)
+    ran_out_of_fuel: bool = False
 
     # Destination zone tracking
     destination_zone: Optional[Zone] = None
@@ -118,7 +119,12 @@ class EntityMetrics:
 
     @property
     def is_out_of_fuel(self) -> bool:
-        return self.fuel <= 0
+        return self.fuel <= 0 or self.ran_out_of_fuel
+
+    def has_fuel_for_step(self) -> bool:
+        """Returns True if the entity has enough fuel to pay for one more step."""
+        tier = self.get_speed_tier()
+        return self.fuel >= tier.fuel_per_step
 
     def get_speed_tier(self) -> SpeedTier:
         return SPEED_TIERS.get(self.speed_tier, SPEED_TIERS["medium"])
@@ -177,7 +183,7 @@ class EntityMetrics:
 # ──────────────────────────────────────────────
 
 def random_entity_metrics(
-    fuel_range: Tuple[float, float] = (60.0, 120.0),
+    fuel_range: Tuple[float, float] = (150.0, 200.0),
     proximity_range: Tuple[int, int] = (2, 5),
     speed_tier: Optional[str] = None,
 ) -> EntityMetrics:

--- a/grid_sim/simulation.py
+++ b/grid_sim/simulation.py
@@ -181,7 +181,13 @@ class SimulationManager:
 
     def _step_simulation(self):
         for movable in self.movables:
-            if hasattr(movable, "metrics") and movable.metrics is not None and movable.metrics.is_out_of_fuel:
+            has_metrics = hasattr(movable, "metrics") and movable.metrics is not None
+
+            # Stop the entity if it can no longer afford a step — check BEFORE moving
+            # so it doesn't get a free move on the tick fuel drops below the step cost.
+            if has_metrics and not movable.metrics.has_fuel_for_step():
+                if not movable.metrics.ran_out_of_fuel:
+                    movable.metrics.ran_out_of_fuel = True
                 self.stats.record_step(movable, False)
                 movable.apply_fire_damage(self.grid)
                 continue
@@ -190,7 +196,7 @@ class SimulationManager:
             movable.apply_fire_damage(self.grid)
             self.stats.record_step(movable, moved)
 
-            if moved and hasattr(movable, "metrics") and movable.metrics is not None:
+            if moved and has_metrics:
                 movable.metrics.burn_fuel_for_step()
                 movable.metrics.check_in_zone(movable.x_pos, movable.y_pos)
                 self._update_proximity(movable)
@@ -210,7 +216,7 @@ class SimulationManager:
 
     def _entity_finished(self, movable: Movable) -> bool:
         metrics = getattr(movable, "metrics", None)
-        return movable.is_done() or (metrics is not None and metrics.is_out_of_fuel)
+        return movable.is_done() or (metrics is not None and (metrics.is_out_of_fuel or metrics.ran_out_of_fuel))
 
     def selected_movables(self) -> List[Movable]:
         return [m for m in self.movables if m.selected]

--- a/grid_sim/stats.py
+++ b/grid_sim/stats.py
@@ -162,6 +162,11 @@ class SimStats:
                 fill_w = int(bar_w * (m.fuel_pct / 100.0))
                 fuel_color = (90, 220, 140) if m.fuel_pct > 50 else (255, 220, 120) if m.fuel_pct > 25 else (240, 120, 120)
                 pygame.draw.rect(window, fuel_color, (bar_x, bar_y, fill_w, bar_h), border_radius=3)
+
+                # Out-of-fuel indicator
+                if m.ran_out_of_fuel:
+                    oof_surf = stat_font.render("OUT OF FUEL", True, (240, 120, 120))
+                    window.blit(oof_surf, (bar_x, bar_y + bar_h + 6))
             else:
                 self._draw_stat(window, stat_font, "Metrics", "N/A", col3_x, row_y)
 


### PR DESCRIPTION
Entities with insufficient fuel for a full step were moving indefinitely for free. Now checks fuel affordability before each move, sets a ran_out_of_fuel flag on first failure, and halts the entity immediately. Summary screen shows "OUT OF FUEL" in red when the flag is set. Also raised the default fuel range (60–120 → 150–200) so entities have enough fuel to complete typical paths without constantly running dry.
<img width="592" height="627" alt="Screenshot 2026-04-15 at 1 24 07 PM" src="https://github.com/user-attachments/assets/4542149b-9eb3-4265-9e57-0aa6ed656362" />
