### PR TITLE
Objective zone takes priority over terrain blocks

### DIFF
--- a/grid_sim/grid.py
+++ b/grid_sim/grid.py
@@ -8,6 +8,7 @@ class Grid:
     def __init__(self):
         self.entities = {}  #{(x, y): entity}
         self.fire_tiles = set() # Mark entity as destroyed when health is depleted
+        self.objective_cells = set()
 
     def add_entity(self, entity):
         self.entities[(entity.x_pos, entity.y_pos)] = entity
@@ -241,7 +242,7 @@ class Grid:
 
                 if not (0 <= x < GRID_WIDTH and 0 <= y < GRID_HEIGHT):
                     continue
-                if (x, y) not in self.entities:
+                if (x, y) not in self.entities and (x, y) not in self.objective_cells:
                     self.add_fire(x, y)
     
     def spread_fire(self):
@@ -261,7 +262,7 @@ class Grid:
              if not (0 <= nx < GRID_WIDTH and 0 <= ny < GRID_HEIGHT):
                 continue
              # Fire should not spread into blocked terrain (walls, water, barriers)
-             if self.is_blocked(nx, ny):
+             if self.is_blocked(nx, ny) or (nx, ny) in self.objective_cells:
                 continue
              # Forest tiles have higher ignition chance
              if self.is_forest(nx, ny):

--- a/grid_sim/simulation.py
+++ b/grid_sim/simulation.py
@@ -60,8 +60,13 @@ class SimulationManager:
         self.grid.rand_gen_forest()
 
         self.objective_cells = self._build_objective_cells()
+
+        # Force objective zone to override terrain
+        for cell in self.dest_zone.all_cells():
+            self.grid.entities.pop(cell, None)
         self._assign_objectives_and_metrics(randomize_metrics=False)
 
+        self.grid.objective_cells = set(self.dest_zone.all_cells())
         self.grid.rand_gen_fire(
             self.movables,
             cluster_count=2,


### PR DESCRIPTION
The objective blocks were sometimes covered by terrain blocks. Now, after terrain generation, all of the terrain blocks within the 4x4 block objective zone are cleared.